### PR TITLE
General cleanup...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.vagrant
+Berksfile.lock
+Gemfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+.bundle
+.cache
+.kitchen
+bin
+.kitchen.local.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## v1.0.0
+
+- Initial release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,257 @@
+# Contributing to Opscode Cookbooks
+
+We are glad you want to contribute to Opscode Cookbooks! The first
+step is the desire to improve the project.
+
+You can find the answers to additional frequently asked questions
+[on the wiki](http://wiki.opscode.com/display/chef/How+to+Contribute).
+
+You can find additional information about
+[contributing to cookbooks](http://wiki.opscode.com/display/chef/How+to+Contribute+to+Opscode+Cookbooks)
+on the wiki as well.
+
+## Quick-contribute
+
+* Create an account on our [bug tracker](http://tickets.opscode.com)
+* Sign our contributor agreement (CLA)
+[ online](https://secure.echosign.com/public/hostedForm?formid=PJIF5694K6L)
+(keep reading if you're contributing on behalf of your employer)
+* Create a ticket for your change on the
+  [bug tracker](http://tickets.opscode.com)
+* Link to your patch as a rebased git branch or pull request from the
+  ticket
+* Resolve the ticket as fixed
+
+We regularly review contributions and will get back to you if we have
+any suggestions or concerns.
+
+## The Apache License and the CLA/CCLA
+
+Licensing is very important to open source projects, it helps ensure
+the software continues to be available under the terms that the author
+desired. Chef uses the Apache 2.0 license to strike a balance between
+open contribution and allowing you to use the software however you
+would like to.
+
+The license tells you what rights you have that are provided by the
+copyright holder. It is important that the contributor fully
+understands what rights they are licensing and agrees to them.
+Sometimes the copyright holder isn't the contributor, most often when
+the contributor is doing work for a company.
+
+To make a good faith effort to ensure these criteria are met, Opscode
+requires a Contributor License Agreement (CLA) or a Corporate
+Contributor License Agreement (CCLA) for all contributions. This is
+without exception due to some matters not being related to copyright
+and to avoid having to continually check with our lawyers about small
+patches.
+
+It only takes a few minutes to complete a CLA, and you retain the
+copyright to your contribution.
+
+You can complete our contributor agreement (CLA)
+[ online](https://secure.echosign.com/public/hostedForm?formid=PJIF5694K6L).
+If you're contributing on behalf of your employer, have your employer
+fill out our
+[Corporate CLA](https://secure.echosign.com/public/hostedForm?formid=PIE6C7AX856)
+instead.
+
+## Ticket Tracker (JIRA)
+
+The [ticket tracker](http://tickets.opscode.com) is the most important
+documentation for the code base. It provides significant historical
+information, such as:
+
+* Which release a bug fix is included in
+* Discussion regarding the design and merits of features
+* Error output to aid in finding similar bugs
+
+Each ticket should aim to fix one bug or add one feature.
+
+## Using git
+
+You can get a quick copy of the repository for this cookbook by
+running `git clone
+git://github.com/opscode-coobkooks/COOKBOOKNAME.git`.
+
+For collaboration purposes, it is best if you create a Github account
+and fork the repository to your own account. Once you do this you will
+be able to push your changes to your Github repository for others to
+see and use.
+
+If you have another repository in your GitHub account named the same
+as the cookbook, we suggest you suffix the repository with -cookbook.
+
+### Branches and Commits
+
+You should submit your patch as a git branch named after the ticket,
+such as COOK-1337. This is called a _topic branch_ and allows users to
+associate a branch of code with the ticket.
+
+It is a best practice to have your commit message have a _summary
+line_ that includes the ticket number, followed by an empty line and
+then a brief description of the commit. This also helps other
+contributors understand the purpose of changes to the code.
+
+    [COOK-1757] - platform_family and style
+
+    * use platform_family for platform checking
+    * update notifies syntax to "resource_type[resource_name]" instead of
+      resources() lookup
+    * COOK-692 - delete config files dropped off by packages in conf.d
+    * dropped debian 4 support because all other platforms have the same
+      values, and it is older than "old stable" debian release
+
+Remember that not all users use Chef in the same way or on the same
+operating systems as you, so it is helpful to be clear about your use
+case and change so they can understand it even when it doesn't apply
+to them.
+
+### Github and Pull Requests
+
+All of Opscode's open source cookbook projects are available on
+[Github](http://www.github.com/opscode-cookbooks).
+
+We don't require you to use Github, and we will even take patch diffs
+attached to tickets on the tracker. However Github has a lot of
+convenient features, such as being able to see a diff of changes
+between a pull request and the main repository quickly without
+downloading the branch.
+
+If you do choose to use a pull request, please provide a link to the
+pull request from the ticket __and__ a link to the ticket from the
+pull request. Because pull requests only have two states, open and
+closed, we can't easily filter pull requests that are waiting for a
+reply from the author for various reasons.
+
+### More information
+
+Additional help with git is available on the
+[Working with Git](http://wiki.opscode.com/display/chef/Working+with+Git)
+wiki page.
+
+## Functional and Unit Tests
+
+This cookbook is set up to run tests under
+[Opscode's test-kitchen](https://github.com/opscode/test-kitchen). It
+uses minitest-chef to run integration tests after the node has been
+converged to verify that the state of the node.
+
+Test kitchen should run completely without exception using the default
+[baseboxes provided by Opscode](https://github.com/opscode/bento).
+Because Test Kitchen creates VirtualBox machines and runs through
+every configuration in the Kitchenfile, it may take some time for
+these tests to complete.
+
+If your changes are only for a specific recipe, run only its
+configuration with Test Kitchen. If you are adding a new recipe, or
+other functionality such as a LWRP or definition, please add
+appropriate tests and ensure they run with Test Kitchen.
+
+If any don't pass, investigate them before submitting your patch.
+
+Any new feature should have unit tests included with the patch with
+good code coverage to help protect it from future changes. Similarly,
+patches that fix a bug or regression should have a _regression test_.
+Simply put, this is a test that would fail without your patch but
+passes with it. The goal is to ensure this bug doesn't regress in the
+future. Consider a regular expression that doesn't match a certain
+pattern that it should, so you provide a patch and a test to ensure
+that the part of the code that uses this regular expression works as
+expected. Later another contributor may modify this regular expression
+in a way that breaks your use cases. The test you wrote will fail,
+signalling to them to research your ticket and use case and accounting
+for it.
+
+If you need help writing tests, please ask on the Chef Developer's
+mailing list, or the #chef-hacking IRC channel.
+
+## Code Review
+
+Opscode regularly reviews code contributions and provides suggestions
+for improvement in the code itself or the implementation.
+
+We find contributions by searching the ticket tracker for _resolved_
+tickets with a status of _fixed_. If we have feedback we will reopen
+the ticket and you should resolve it again when you've made the
+changes or have a response to our feedback. When we believe the patch
+is ready to be merged, we will tag the _Code Reviewed_ field with
+_Reviewed_.
+
+Depending on the project, these tickets are then merged within a week
+or two, depending on the current release cycle.
+
+## Release Cycle
+
+The versioning for Opscode Cookbook projects is X.Y.Z.
+
+* X is a major release, which may not be fully compatible with prior
+  major releases
+* Y is a minor release, which adds both new features and bug fixes
+* Z is a patch release, which adds just bug fixes
+
+A released version of a cookbook will end in an even number, e.g.
+"1.2.4" or "0.8.0". When development for the next version of the
+cookbook begins, the "Z" patch number is incremented to the next odd
+number, however the next release of the cookbook may be a major or
+minor incrementing version.
+
+Releases of Opscode's cookbooks are usually announced on the Chef user
+mailing list. Releases of several cookbooks may be batched together
+and announced on the [Opscode Blog](http://www.opscode.com/blog).
+
+## Working with the community
+
+These resources will help you learn more about Chef and connect to
+other members of the Chef community:
+
+* [chef](http://lists.opscode.com/sympa/info/chef) and
+  [chef-dev](http://lists.opscode.com/sympa/info/chef-dev) mailing
+  lists
+* #chef and #chef-hacking IRC channels on irc.freenode.net
+* [Community Cookbook site](http://community.opscode.com)
+* [Chef wiki](http://wiki.opscode.com/display/chef)
+* Opscode Chef [product page](http://www.opscode.com/chef)
+
+
+## Cookbook Contribution Do's and Don't's
+
+Please do include tests for your contribution. If you need help, ask
+on the
+[chef-dev mailing list](http://lists.opscode.com/sympa/info/chef-dev)
+or the
+[#chef-hacking IRC channel](http://community.opscode.com/chat/chef-hacking).
+Not all platforms that a cookbook supports may be supported by Test
+Kitchen. Please provide evidence of testing your contribution if it
+isn't trivial so we don't have to duplicate effort in testing. Chef
+10.14+ "doc" formatted output is sufficient.
+
+Please do indicate new platform (families) or platform versions in the
+commit message, and update the relevant ticket.
+
+If a contribution adds new platforms or platform versions, indicate
+such in the body of the commit message(s), and update the relevant
+COOK ticket. When writing commit messages, it is helpful for others if
+you indicate the COOK ticket. For example:
+
+    git commit -m '[COOK-1041] - Updated pool resource to correctly
+    delete.'
+
+Please do use [foodcritic](http://acrmp.github.com/foodcritic) to
+lint-check the cookbook. Except FC007, it should pass all correctness
+rules. FC007 is okay as long as the dependent cookbooks are *required*
+for the default behavior of the cookbook, such as to support an
+uncommon platform, secondary recipe, etc.
+
+Please do ensure that your changes do not break or modify behavior for
+other platforms supported by the cookbook. For example if your changes
+are for Debian, make sure that they do not break on CentOS.
+
+Please do not modify the version number in the metadata.rb, Opscode
+will select the appropriate version based on the release cycle
+information above.
+
+Please do not update the CHANGELOG.md for a new version. Not all
+changes to a cookbook may be merged and released in the same versions.
+Opscode will update the CHANGELOG.md when releasing a new version of
+the cookbook.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -18,21 +18,21 @@
 # limitations under the License.
 #
 
-default['opscode_backup']['rsyncd']['config_file'] = "/etc/rsyncd.conf"
-default['opscode_backup']['rsyncd']['opts'] = ""
+default['opscode_backup']['rsyncd']['config_file'] = '/etc/rsyncd.conf'
+default['opscode_backup']['rsyncd']['opts'] = ''
 default['opscode_backup']['rsyncd']['nice'] = 10
 default['opscode_backup']['rsyncd']['max_conn'] = 0
 default['opscode_backup']['rsyncd']['timeout'] = 900  # 0 to disable
-default['opscode_backup']['rsyncd']['strict'] = "true"
-default['opscode_backup']['rsyncd']['secrets_file'] = "/etc/rsyncd.secrets" # change secrets_file to "" if you don't need it written or used in config_file
-default['opscode_backup']['rsyncd']['enable'] = "true"
+default['opscode_backup']['rsyncd']['strict'] = 'true'
+default['opscode_backup']['rsyncd']['secrets_file'] = '/etc/rsyncd.secrets' # change secrets_file to "" if you don't need it written or used in config_file
+default['opscode_backup']['rsyncd']['enable'] = 'true'
 
 default['opscode_backup']['retention']['hours']  = 24
 default['opscode_backup']['retention']['days']   = 7
 default['opscode_backup']['retention']['weeks']  = 8
 default['opscode_backup']['retention']['months'] = 6
 
-default['opscode_backup']['mailto_addr'] = ""
+default['opscode_backup']['mailto_addr'] = ''
 default['opscode_backup']['offsite_servers'] = [
   # {
     # 'host' => 'offsite-backups.example.com',

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,1 @@
+This directory contains usage examples.

--- a/examples/metadata.rb
+++ b/examples/metadata.rb
@@ -1,0 +1,2 @@
+name 'examples'
+description 'Not a real cookbook. These are examples to use in your own cookbook(s)'

--- a/examples/recipes/backup.rb
+++ b/examples/recipes/backup.rb
@@ -18,31 +18,31 @@
 
 # This is an example recipe that uses the opscode_backup lwrp
 
-include_recipe "opscode-backup::client"
+include_recipe 'opscode-backup::client'
 
 rsyncd_server = search(:node, "role:backup-server AND chef_environment:#{node.chef_environment}").first
 unless rsyncd_server
-  Chef::Log.info "No rsync servers found, skipping opscode-backups::client"
+  Chef::Log.info 'No rsync servers found, skipping opscode-backups::client'
   return
 end
 
-cookbook_file "/usr/local/bin/database_backup.sh" do
-  source "database_backup.sh.erb"
-  owner "root"
-  group "root"
-  mode "0755"
+cookbook_file '/usr/local/bin/database_backup.sh' do
+  source 'database_backup.sh.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
 end
 
 directory node['db']['backup_dir']
 directory "#{node['db']['backup_dir']}/current"
 directory "#{node['db']['backup_dir']}/archive"
 
-opscode_backup "db" do
+opscode_backup 'db' do
   server rsyncd_server['fqdn']
   directory "#{node['db']['backup_dir']}/current"
-  cron_schedule "0 * * * *"
-  target "db"
-  password_file node[:opscode_backup][:rsyncd][:secrets_file]
-  pre_cmd "/usr/local/bin/database_backup.sh"
+  cron_schedule '0 * * * *'
+  target 'db'
+  password_file node['opscode_backup']['rsyncd']['secrets_file']
+  pre_cmd '/usr/local/bin/database_backup.sh'
   post_cmd "find #{node['db']['backup_dir']}/archive -type f -cmin +180 -exec rm -rf {} \;"
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,3 @@ maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Manages rsync based backups"
 version           "1.0.0"
-
-%w{ ubuntu debian }.each do |os|
-  supports os
-end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -24,13 +24,13 @@ use_inline_resources
 action :create do
   package 'rsync'
 
-  cookbook_file "/usr/local/bin/rsync-backups.sh" do
-    cookbook "opscode-backup"
-    source "rsync-backups.sh"
+  cookbook_file '/usr/local/bin/rsync-backups.sh' do
+    cookbook 'opscode-backup'
+    source 'rsync-backups.sh'
     backup false
-    owner "root"
-    group "root"
-    mode "0755"
+    owner 'root'
+    group 'root'
+    mode '0755'
   end
 
   directory new_resource.directory
@@ -50,10 +50,10 @@ action :create do
   end
 
   Chef::Log.debug "#{new_resource.name} tagging node"
-  if node[:tags].length > 0
-    node.normal[:tags] << 'backupclient' unless node[:tags].include?('backupclient')
+  if node['tags'].length > 0
+    node.normal['tags'] << 'backupclient' unless node['tags'].include?('backupclient')
   else
-    node.normal[:tags] = ['backupclient']
+    node.normal['tags'] = ['backupclient']
   end
 
   node.normal['opscode_backup']['targets'] = Array(node['opscode_backup']['targets']).dup.push(new_resource.target)

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -20,12 +20,12 @@
 package 'rsync'
 
 # secrets!
-template node[:opscode_backup][:rsyncd][:secrets_file] do
-  source "rsync-client.secrets.erb"
-  owner "root"
-  group "root"
-  mode "0600"
+template node['opscode_backup']['rsyncd']['secrets_file'] do
+  source 'rsync-client.secrets.erb'
+  owner 'root'
+  group 'root'
+  mode '0600'
   variables(
-    :rsyncd_password => data_bag_item("secrets", node.chef_environment)['rsyncd_password']
+    :rsyncd_password => data_bag_item('secrets', node.chef_environment)['rsyncd_password']
   )
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,4 +17,4 @@
 # limitations under the License.
 #
 
-include_recipe "opscode-backup::client"
+include_recipe 'opscode-backup::client'

--- a/recipes/offsite.rb
+++ b/recipes/offsite.rb
@@ -17,12 +17,12 @@
 # limitations under the License.
 #
 
-package "rsync"
+package 'rsync'
 
-user "rsync" do
-  comment "Rsync User"
-  home    "/backup"
-  shell   "/bin/bash"
+user 'rsync' do
+  comment 'Rsync User'
+  home    '/backup'
+  shell   '/bin/bash'
   system  true
 end
 
@@ -32,8 +32,8 @@ end.flatten
 
 backup_targets.each do |backup|
   directory "/backup/#{backup}" do
-    owner "rsync"
-    group "rsync"
-    mode "0755"
+    owner 'rsync'
+    group 'rsync'
+    mode '0755'
   end
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -21,8 +21,8 @@ backup_targets = search(:node, 'tags:backupclient').collect do |node|
   node['opscode_backup']['targets']
 end.flatten
 
-secrets = data_bag_item("secrets", node.chef_environment)
-aws_preprod = data_bag_item("aws", "rs-preprod")
+secrets = data_bag_item('secrets', node.chef_environment)
+aws_preprod = data_bag_item('aws', 'rs-preprod')
 
 %w{rsync libxml2-dev libxslt-dev logtail libdatetime-perl}.each do |pkg|
   package pkg do
@@ -30,98 +30,98 @@ aws_preprod = data_bag_item("aws", "rs-preprod")
   end
 end
 
-template "/etc/default/rsync" do
-  source "rsync-default.erb"
-  owner "root"
-  group "root"
-  mode "0644"
-  notifies :restart, "service[rsync]"
+template '/etc/default/rsync' do
+  source 'rsync-default.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[rsync]'
 end
 
 # Set up the rsync user for ssh copies
-user "rsync" do
-  comment "Rsync User"
-  home    "/backup"
-  shell   "/bin/bash"
+user 'rsync' do
+  comment 'Rsync User'
+  home    '/backup'
+  shell   '/bin/bash'
   system  true
 end
-directory "/backup" do
-  owner "rsync"
-  group "rsync"
-  mode "0755"
+directory '/backup' do
+  owner 'rsync'
+  group 'rsync'
+  mode '0755'
 end
-directory "/backup/.ssh" do
-  owner "rsync"
-  group "rsync"
-  mode "0700"
+directory '/backup/.ssh' do
+  owner 'rsync'
+  group 'rsync'
+  mode '0700'
 end
-file "/backup/.ssh/id_rsa" do
-  content secrets["rsync-backups-user.priv"]
-  mode "0600"
-  owner "rsync"
-  group "rsync"
+file '/backup/.ssh/id_rsa' do
+  content secrets['rsync-backups-user.priv']
+  owner 'rsync'
+  group 'rsync'
+  mode '0600'
 end
 
 backup_targets.each do |backup|
   directory "/backup/#{backup}" do
-    owner "rsync"
-    group "rsync"
-    mode "0755"
+    owner 'rsync'
+    group 'rsync'
+    mode '0755'
   end
 end
 
-template "#{node[:opscode_backup][:rsyncd][:config_file]}" do
-  source "rsyncd.conf.erb"
-  owner "root"
-  group "root"
-  mode "0644"
+template node['opscode_backup']['rsyncd']['config_file'] do
+  source 'rsyncd.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
   variables(
     :backups => backup_targets
   )
-  notifies :restart, "service[rsync]"
+  notifies :restart, 'service[rsync]'
 end
 
 # secrets!
-template "#{node[:opscode_backup][:rsyncd][:secrets_file]}" do
-  source "rsync.secrets.erb"
-  owner "root"
-  group "root"
+template node['opscode_backup']['rsyncd']['secrets_file'] do
+  source 'rsync.secrets.erb'
+  owner 'root'
+  group 'root'
   mode "0600"
   variables(
-    :rsyncd_password => data_bag_item("secrets", node.chef_environment)['rsyncd_password']
+    :rsyncd_password => data_bag_item('secrets', node.chef_environment)['rsyncd_password']
   )
-  notifies :restart, "service[rsync]"
+  notifies :restart, 'service[rsync]'
 end
 
-cookbook_file "/usr/local/bin/rsync-backup-pre.sh" do
-  source "rsync-backup-pre.sh"
-  owner "root"
-  group "root"
-  mode "0755"
+cookbook_file '/usr/local/bin/rsync-backup-pre.sh' do
+  source 'rsync-backup-pre.sh'
+  owner 'root'
+  group 'root'
+  mode '0755'
 end
 
-template "/usr/local/bin/rsync-backup-post.sh" do
-  source "rsync-backup-post.sh.erb"
-  owner "root"
-  group "root"
-  mode "0755"
+template '/usr/local/bin/rsync-backup-post.sh' do
+  source 'rsync-backup-post.sh.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
 end
 
-cookbook_file "/usr/local/bin/backup-rotate" do
-  source "backup-rotate"
-  owner "root"
-  group "root"
-  mode "0755"
+cookbook_file '/usr/local/bin/backup-rotate' do
+  source 'backup-rotate'
+  owner 'root'
+  group 'root'
+  mode '0755'
 end
 
-template "/etc/cron.d/offsite-backups-push" do
-  source "offsite-backups-push-cron.erb"
-  owner "root"
-  group "root"
-  mode "0600"
+template '/etc/cron.d/offsite-backups-push' do
+  source 'offsite-backups-push-cron.erb'
+  owner 'root'
+  group 'root'
+  mode '0600'
 end
 
-service "rsync" do
+service 'rsync' do
   action [:enable, :start]
   supports :restart => true, :reload => true
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -22,7 +22,7 @@ default_action :create
 attribute :target, :kind_of => String, :name_attribute => true
 attribute :server, :kind_of => String, :required => true
 attribute :directory, :kind_of => String, :required => true
-attribute :cron_schedule, :kind_of => String, :default => "0 * * * *"
+attribute :cron_schedule, :kind_of => String, :default => '0 * * * *'
 attribute :pre_cmd, :kind_of => [String, NilClass], :default => nil
 attribute :post_cmd, :kind_of => [String, NilClass], :default => nil
 attribute :password_file, :kind_of => [String, NilClass], :default => nil

--- a/templates/default/rsync-default.erb
+++ b/templates/default/rsync-default.erb
@@ -6,7 +6,7 @@
 #  Use "inetd" if you want to start the rsyncd from inetd,
 #  all this does is prevent the init.d script from printing a message
 #  about not starting rsyncd (you still need to modify inetd's config yourself).
-RSYNC_ENABLE=<%= node[:opscode_backup][:rsyncd][:enable] %>
+RSYNC_ENABLE=<%= node['opscode_backup']['rsyncd']['enable'] %>
 
 # which file should be used as the configuration file for rsync.
 # This file is used instead of the default /etc/rsyncd.conf
@@ -14,20 +14,20 @@ RSYNC_ENABLE=<%= node[:opscode_backup][:rsyncd][:enable] %>
 #          using a remote shell. When using a different file for
 #          rsync you might want to symlink /etc/rsyncd.conf to
 #          that file.
-RSYNC_CONFIG_FILE=<%= node[:opscode_backup][:rsyncd][:config_file] %>
+RSYNC_CONFIG_FILE=<%= node['opscode_backup']['rsyncd']['config_file'] %>
 
 # what extra options to give rsync --daemon?
 #  that excludes the --daemon; that's always done in the init.d script
 #  Possibilities are:
 #   --address=123.45.67.89		(bind to a specific IP address)
 #   --port=8730				(bind to specified port; default 873)
-RSYNC_OPTS='<%= node[:opscode_backup][:rsyncd][:opts] %>'
+RSYNC_OPTS='<%= node['opscode_backup']['rsyncd']['opts'] %>'
 
 # run rsyncd at a nice level?
 #  the rsync daemon can impact performance due to much I/O and CPU usage,
 #  so you may want to run it at a nicer priority than the default priority.
 #  Allowed values are 0 - 19 inclusive; 10 is a reasonable value.
-RSYNC_NICE='<%= node[:opscode_backup][:rsyncd][:nice] %>'
+RSYNC_NICE='<%= node['opscode_backup']['rsyncd']['nice'] %>'
 
 # run rsyncd with ionice?
 #  "ionice" does for IO load what "nice" does for CPU load.
@@ -36,8 +36,8 @@ RSYNC_NICE='<%= node[:opscode_backup][:rsyncd][:nice] %>'
 #  See the manpage for ionice for allowed options.
 #  -c3 is recommended, this will run rsync IO at "idle" priority. Uncomment
 #  the next line to activate this.
-<% if node[:opscode_backup][:rsyncd][:ionice] -%>
-RSYNC_IONICE='-c<%= node[:opscode_backup][:rsyncd][:ionice] %>'
+<% if node['opscode_backup']['rsyncd']['ionice'] -%>
+RSYNC_IONICE='-c<%= node['opscode_backup']['rsyncd']['ionice'] %>'
 <% end -%>
 
 # Don't forget to create an appropriate config file,

--- a/templates/default/rsyncd.conf.erb
+++ b/templates/default/rsyncd.conf.erb
@@ -1,11 +1,11 @@
 # Managed by Chef
-max connections = <%= node[:opscode_backup][:rsyncd][:max_conn] %>
+max connections = <%= node['opscode_backup']['rsyncd']['max_conn'] %>
 log file = /var/log/rsync.log
-timeout = <%= node[:opscode_backup][:rsyncd][:timeout] %>
-strict modes = <%= node[:opscode_backup][:rsyncd][:strict] %>
+timeout = <%= node['opscode_backup']['rsyncd']['timeout'] %>
+strict modes = <%= node['opscode_backup']['rsyncd']['strict'] %>
 
 auth users = rsync
-secrets file = <%= node[:opscode_backup][:rsyncd][:secrets_file] %>
+secrets file = <%= node['opscode_backup']['rsyncd']['secrets_file'] %>
 read only = no
 uid = rsync
 pre-xfer exec = /usr/local/bin/rsync-backup-pre.sh

--- a/templates/default/rsyncd.excludes.erb
+++ b/templates/default/rsyncd.excludes.erb
@@ -1,4 +1,4 @@
 # Managed by Chef
-<% @backup.each do |excludes| -%> 
+<% @backup.each do |excludes| -%>
 <%= excludes %>
 <% end -%>


### PR DESCRIPTION
- Create files we typically include in open source
  cookbooks (changelog, contributing, license)
- Use single quoted strings for attribute keys everywhere
- Resolve foodcritic findings (attributes, unnecessary string
  interpolation)
- Even though its not a real cookbook, resolve foodcritic findings in
  examples directory.
